### PR TITLE
fall back to _$jscoverage

### DIFF
--- a/phantom_jasmine_runner.js
+++ b/phantom_jasmine_runner.js
@@ -12,7 +12,7 @@ PhantomJasmineRunner = (function() {
   PhantomJasmineRunner.prototype.get_status = function() {
     return this.page.evaluate(function(threshold) {
       if (window.jasmine_phantom_reporter.status === "success"){
-        if (!window.travisCov.check(window._$blanket,{threshold: threshold})){
+        if (!window.travisCov.check( (window._$blanket || window._$jscoverage),{threshold: threshold})){
           return "fail";
         }else{
           return "success";
@@ -25,7 +25,7 @@ PhantomJasmineRunner = (function() {
 
   PhantomJasmineRunner.prototype.terminate = function() {
     switch (this.get_status()) {
-      case "success":   
+      case "success":
         return this.exit_func(0);
       case "fail":
         return this.exit_func(1);
@@ -70,7 +70,7 @@ page.open(address, function(status) {
     console.log("can't load the address!");
     phantom.exit(1);
   }
-  
-  
+
+
 });
 

--- a/phantom_mocha_runner.js
+++ b/phantom_mocha_runner.js
@@ -23,7 +23,7 @@ page.onConsoleMessage = function(msg) {
 
 page.onInitialized = function() {
     page.injectJs('travisCov.js');
-    
+
 };
 
 page.open(url, function(status){
@@ -53,11 +53,11 @@ function onfinishedTests() {
     var output = page.evaluate(function(threshold) {
             //print a success message
             var retval=0;
-            if (!window.travisCov.check(window._$blanket,{threshold: threshold})){
+            if (!window.travisCov.check( (window._$blanket || window._$jscoverage),{threshold: threshold})){
                     retval=1;
             }
             return retval;
-                    
+
     });
     phantom.exit(output > 0 ? 1 : 0);
 }

--- a/phantom_runner.js
+++ b/phantom_runner.js
@@ -25,25 +25,25 @@ page.onConsoleMessage = function(msg) {
 
 page.onInitialized = function() {
     page.injectJs('travisCov.js');
-    
+
     page.evaluate(addLogging,threshold);
-    
+
 };
 page.open(url, function(status){
     if (status !== "success") {
         console.log("Unable to access network: " + status);
         phantom.exit(1);
     } else {
-        
-        
+
+
         var interval = setInterval(function() {
             if (finished()) {
                 clearInterval(interval);
                 onfinishedTests();
             }
         }, 500);
-    
-        
+
+
     }
 });
 
@@ -61,8 +61,8 @@ function onfinishedTests() {
 }
 
 function addLogging(threshold) {
-    
-       
+
+
         window.document.addEventListener( "DOMContentLoaded", function() {
             var current_test_assertions = [],
                 DOMbound=true;
@@ -103,19 +103,19 @@ function addLogging(threshold) {
             });
 
             QUnit.done(function(result){
-               
+
                 if (result.passed === 0){
                     console.log("failed: no tests run.");
                     result.failed=1;
-                }else if (! window._$blanket ){
+                }else if (!  (window._$blanket || window._$jscoverage) ){
                     console.log("failed: no coverage info.");
                     result = result.failed > 0 ? result : {failed: 1};
-                }else if ( !window.travisCov.check(window._$blanket,{threshold: threshold})){
-                    console.log("failed:"+window._$blanket);
+                }else if ( !window.travisCov.check( (window._$blanket || window._$jscoverage),{threshold: threshold})){
+                    console.log("failed:"+ (window._$blanket || window._$jscoverage));
                     result = {failed:1};
                 }
                 window.qunitDone = result;
             });
         }, false );
-    
+
 }


### PR DESCRIPTION
Hi @alex-seville.

I was kicking myself trying to figure out why the test I wrote for my blanket changes was failing until I realized it was the reporter... so before I can make a passing test for my blanket changes, I had to do this.

If window._$blanket is not defined, fall back to window._$jscoverage.

This allows blanket coverage for files that are pre-instrumented with grunt-blanket.
