### PR TITLE
Clean up README and obsolete options

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,9 +7,7 @@ Threshold is specified in the "package.json" file of the consuming project.
 Add the key `travis-cov` to the `config` key in your "package.json" file.  Under that key, you can add any of the following properties:
 
 ```
-"threshold": <number>,
-"global": <boolean>,
-"local": <boolean>
+"threshold": <number>
 ```
 
 See [Blanket.js's "package.json"](https://github.com/alex-seville/blanket/blob/master/package.json#L64-L67) as an example.

--- a/README.md
+++ b/README.md
@@ -1,21 +1,24 @@
 ## travis-cov
 
-A coverage reporter for [Mocha](http://visionmedia.github.com/mocha/)/[Blanket](http://blanketjs.org/) that will fail a [travis-ci](https://travis-ci.org/) build when the coverage threshold is too low.
+A coverage reporter for [Mocha](https://mochajs.org/)/[Blanket](http://blanketjs.org/) that will fail a [Travis CI](https://travis-ci.org/) build when the coverage threshold is too low.
 
-Threshold is specified in the package.json file of the consuming project.
+Threshold is specified in the "package.json" file of the consuming project.
 
-Add the key `"travis-cov" to the "config" key in your package.json file.  Under that key you can add any of the following properties:
+Add the key `travis-cov` to the `config` key in your "package.json" file.  Under that key, you can add any of the following properties:
 
-`threshold: <number>,
-global: <boolean>,
-local: <boolean>`
+```
+"threshold": <number>,
+"global": <boolean>,
+"local": <boolean>
+```
 
-See [Blanket.js's package.json](https://github.com/alex-seville/blanket/blob/master/package.json#L42) as an example.
+See [Blanket.js's "package.json"](https://github.com/alex-seville/blanket/blob/master/package.json#L64-L67) as an example.
 
-###usage
-1. `npm install travis-cov`
-2. Use a reporter argument, `mocha -R travis-cov`
-3. Change scripts.test in your package.json file to use `mocha -R travis-cov`
-4. Add `travis-cov` to the package.json file in the config section.  Add whichever keys you want (see above).
-5. Set up your project with travis-ci
-6. Commit, if your tests pass and the code coverage is above the threshold the build will pass, otherwise it will fail.
+### Usage
+
+ 1. `npm install travis-cov`
+ 2. Use a reporter argument, `mocha -R travis-cov`
+ 3. Change the `scripts.test` property in your "package.json" file to use `mocha -R travis-cov`
+ 4. Add `travis-cov` to the "package.json" file in the `config` section. Add whichever keys you want (see above).
+ 5. Set up your project with Travis CI
+ 6. Commit. If your tests pass and the code coverage is above the threshold then the build will pass; if not, the build will fail.

--- a/index.js
+++ b/index.js
@@ -2,8 +2,6 @@
 var fs = require("fs"),
     PACKAGE_KEY = "travis-cov",
     THRESHOLD_KEY = "threshold",
-    GLOBAL_KEY = "global",
-    LOCAL_KEY = "local",
     REMOVE_KEY = "removeKey",
     travisCov = require("./travisCov").travisCov;
 
@@ -52,8 +50,6 @@ function TrvsCov(runner) {
 
           if (userOpts){
             options.threshold = userOpts[THRESHOLD_KEY] || options.threshold;
-            options.global = userOpts[GLOBAL_KEY] || options.global;
-            options.local = userOpts[LOCAL_KEY] || options.local;
             options.removeKey = userOpts[REMOVE_KEY];
           }
         }


### PR DESCRIPTION
- The README needed some love.
- Finished the job of removing the former options `global` and `local` completely
  - Original commit that removed their functionality: https://github.com/alex-seville/travis-cov/commit/b161763bcea56643fd5968cb04abe12705f552aa
