### PR TITLE
Allow threshold to be set via an environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,12 @@ local: <boolean>`
 
 See [Blanket.js's package.json](https://github.com/alex-seville/blanket/blob/master/package.json#L42) as an example.
 
+Alternatively, the desired threshold can be specified by setting its value in an environment variable named `TRAVIS_COV_THRESHOLD`. For example, to set the threshold to 75% from a UNIX-style shell:
+
+```shell
+TRAVIS_COV_THRESHOLD=75 mocha -R travis-cov
+```
+
 ###usage
 1. `npm install travis-cov`
 2. Use a reporter argument, `mocha -R travis-cov`

--- a/index.js
+++ b/index.js
@@ -5,6 +5,7 @@ var fs = require("fs"),
     GLOBAL_KEY = "global",
     LOCAL_KEY = "local",
     REMOVE_KEY = "removeKey",
+    THRESHOLD_ENV_KEY = "TRAVIS_COV_THRESHOLD",
     travisCov = require("./travisCov").travisCov;
 
 
@@ -29,7 +30,12 @@ exports = module.exports =  TrvsCov;
 function TrvsCov(runner) {
   runner.on('end', function(){
     var cov = global._$jscoverage || {},
-      options = {};
+      options = {},
+      envThreshold = parseInt(process.env[THRESHOLD_ENV_KEY], 10);
+
+    if (envThreshold){
+      options.threshold = envThreshold;
+    }
 
     var path = process.cwd() + '/package.json';
 
@@ -51,7 +57,7 @@ function TrvsCov(runner) {
           }
 
           if (userOpts){
-            options.threshold = userOpts[THRESHOLD_KEY] || options.threshold;
+            options.threshold = options.threshold || userOpts[THRESHOLD_KEY];
             options.global = userOpts[GLOBAL_KEY] || options.global;
             options.local = userOpts[LOCAL_KEY] || options.local;
             options.removeKey = userOpts[REMOVE_KEY];


### PR DESCRIPTION
For me, having to specify a configuration in my "package.json" file is a very foreign concept.  I would prefer to have the option of controlling _at least_ the `threshold` option via an environment variable.

This would also make it much easier to control when utilizing this module from within other systems (e.g. in the "Gruntfile.js" file for Grunt build setups) without having to bloat the "package.json" file (which must be included in every NPM-published version of the module).
